### PR TITLE
fix: mate 태그 캐시 import 시점 호출 제거 및 실패 격리

### DIFF
--- a/app/features/matetag/service.py
+++ b/app/features/matetag/service.py
@@ -3,15 +3,12 @@ from dotenv import load_dotenv
 from langchain_naver import ChatClovaX
 from .tag_prompt import tag_prompt
 from pydantic import BaseModel, Field
-from .tag_cache import tag_cache
+from .tag_cache import get_tag_cache
 from typing import List
 
 load_dotenv()
 
-# TagResult를 with_structured_output()에 넘기면 LLM이 구조에 맞춰서 응답함
 class TagResult(BaseModel):
-    """ 메이트 작성글을 바탕으로 태그 추출 결과"""
-
     style_tags: List[str] = Field(
         description="여행 방식 태그 (STYLE 카테고리에서 1~2개)"
     )
@@ -20,8 +17,6 @@ class TagResult(BaseModel):
     )
 
 class TagExtractRequest(BaseModel):
-    """ Spring Boot에서 넘어오는 요청 """
-
     post_id: int
     content: str
     destination: str
@@ -29,6 +24,8 @@ class TagExtractRequest(BaseModel):
 def extract_tags(request: TagExtractRequest) -> TagResult:
     llm = ChatClovaX(model="HCX-007", max_tokens=1024, thinking={"effort" : "none"})
     structured_llm = llm.with_structured_output(TagResult, method="json_schema")
+
+    tag_cache = get_tag_cache()
 
     prompt = tag_prompt.invoke({
         "style_tags": ", ".join(tag_cache["style"]),

--- a/app/features/matetag/tag_cache.py
+++ b/app/features/matetag/tag_cache.py
@@ -1,11 +1,10 @@
 import httpx
 from functools import lru_cache
-
-SPRING_BOOT_URL = "http://localhost:8080"  # application.yml 포트에 맞춰
+import os
 
 @lru_cache(maxsize=1)
 def get_tag_cache() -> dict[str, set[str]]:
-    response = httpx.get(f"{SPRING_BOOT_URL}/api/mate/tags")
+    response = httpx.get(f"{os.getenv('SPRING_BOOT_URL')}/api/mate/tags")
     response.raise_for_status()
 
     result = {"style": set(), "vibe": set()}


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #31, #32

---
## 🎨 작업 내용 (What)
- matetag `tag_cache`를 import 시점 eager 초기화에서 지연 로딩으로 전환
- 실제 fetch(`_fetch_tag_cache` + `lru_cache`)와 예외 격리 래퍼(`get_tag_cache`) 분리
- 태그 조회 실패 시 예외를 삼키고 빈 캐시 반환, 로그는 `debug` 레벨로만 출력
- `SPRING_BOOT_URL`을 `os.getenv` 기반으로 유지, `httpx` timeout(5초) 및 style/vibe 외 category KeyError 방어 추가
- `service.py` 호출부를 `get_tag_cache()` 호출 방식으로 변경

---
## 🧭 작업 목적 (Why)
matetag가 앱 import 시점에 Spring Boot(`/api/mate/tags`)를 동기 호출하는 구조라, 태그 조회 실패 시 matetag뿐 아니라 같은 앱에 묶인 schedule 등 타 기능까지 함께 영향받았음. `lru_cache`가 실패를 캐싱하지 않아 실패가 반복되며 에러 로그도 폭주함. 이를 지연 로딩 + 예외 격리로 전환해, 앱 기동을 안정화하고 태그 데이터가 없는 환경에서도 다른 기능이 정상 동작하도록 개선.

---
## 🧩 변경 범위
- [ ] API 엔드포인트
- [x] 서버 로직
- [ ] 요청 / 응답 구조
- [x] 예외 처리
- [x] 설정 / 환경

---
## 🧪 테스트 방법
- [x] 로컬 실행 확인 (앱 기동 시 Spring Boot 호출 미발생)
- [x] API 호출 테스트 (`POST /mate/extract` 정상 응답)
- [x] 에러 로그 확인 (태그 데이터 없을 때 반복 traceback 미발생)

---
## ⚠️ 참고 사항
- `_fetch_tag_cache`와 `get_tag_cache`를 분리한 이유: `get_tag_cache`에 바로 `@lru_cache` + try/except를 걸면 빈 캐시가 캐싱되어 이후 태그가 채워져도 반영되지 않음. 실패는 캐싱하지 않고 다음 호출에서 재시도되도록 의도적으로 분리함
- `lru_cache`는 성공 결과를 프로세스 생존 동안 유지하므로, 운영 중 태그 변경 시 반영되지 않는 한계는 그대로 남음 (TTL 캐시/무효화는 별도 이슈로 분리 예정)
- Docker(`backend`) / 로컬(`localhost`) 환경 차이는 `.env`의 `SPRING_BOOT_URL`로 대응

---
## ✅ 체크리스트
- [x] main 브랜치에 직접 push 하지 않음
- [x] 해당 브랜치에서 작업함
- [x] 불필요한 print / debug 코드 제거
- [x] PR 단위가 과도하게 크지 않음