### PR TITLE
[AI] feature: 금칙어 AI 필터링 기능 구현

### DIFF
--- a/app/features/badword/models.py
+++ b/app/features/badword/models.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+class BadwordRequest(BaseModel):
+    text: str
+
+class BadwordResponse(BaseModel):
+    isBlocked: bool
+    reason: str

--- a/app/features/badword/router.py
+++ b/app/features/badword/router.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter, HTTPException
+from features.badword.models import BadwordRequest, BadwordResponse
+from features.badword.service import check_badword
+
+router = APIRouter(prefix="/badword", tags=["badword"])
+
+@router.post("/check", response_model=BadwordResponse)
+async def check(request: BadwordRequest):
+    try:
+        return check_badword(request)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))

--- a/app/features/badword/service.py
+++ b/app/features/badword/service.py
@@ -1,0 +1,67 @@
+import json
+import httpx
+import uuid
+from config import BADWORD_API_KEY, BADWORD_API_URL
+from features.badword.models import BadwordRequest, BadwordResponse
+
+def check_badword(request: BadwordRequest) -> BadwordResponse:
+    try:
+        prompt = _build_prompt(request.text)
+        raw_content = _call_clova(prompt)
+        return _parse_llm_response(raw_content)
+    except Exception as e:
+        print(f"[badword] LLM 분석 실패: {e}")
+        return BadwordResponse(isBlocked=False, reason="")
+
+def _build_prompt(text: str) -> str:
+    return f"""
+너는 여행 커뮤니티 서비스의 금칙어 필터링 도우미야.
+다음 텍스트에 욕설, 비하, 혐오 표현 등 부적절한 내용이 있는지 판단해줘.
+
+규칙:
+1. 응답은 반드시 JSON 객체 하나만 반환해.
+2. 설명 문장, 마크다운, 코드블록 없이 JSON만 반환해.
+
+입력 텍스트:
+{text}
+
+반드시 아래 JSON 형식으로만 반환해.
+{{
+  "isBlocked": true,
+  "reason": "욕설 포함"
+}}
+""".strip()
+
+def _call_clova(prompt: str) -> str:
+    headers = {
+        "Authorization": f"Bearer {BADWORD_API_KEY}",
+        "X-NCP-CLOVASTUDIO-REQUEST-ID": str(uuid.uuid4()),
+        "Content-Type": "application/json",
+        "Accept": "application/json",
+    }
+    body = {
+        "messages": [
+            {"role": "system", "content": "너는 금칙어 필터링 도우미다. JSON만 반환한다."},
+            {"role": "user", "content": prompt},
+        ],
+        "topP": 0.8,
+        "topK": 0,
+        "maxTokens": 256,
+        "temperature": 0.2,
+        "repeatPenalty": 1.1,
+    }
+    with httpx.Client() as client:
+        response = client.post(BADWORD_API_URL, headers=headers, json=body, timeout=20)
+        response.raise_for_status()
+        data = response.json()
+        return data["result"]["message"]["content"]
+
+def _parse_llm_response(raw_content: str) -> BadwordResponse:
+    cleaned = raw_content.strip()
+    if cleaned.startswith("```"):
+        cleaned = cleaned.replace("```json", "").replace("```", "").strip()
+    data = json.loads(cleaned)
+    return BadwordResponse(
+        isBlocked=data.get("isBlocked", False),
+        reason=data.get("reason", "")
+    )

--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from fastapi.responses import HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.templating import Jinja2Templates
 from features.ocr.router import router as ocr_router
+from features.badword.router import router as badword_router
 import uvicorn
 
 import sys, os
@@ -28,6 +29,7 @@ app.add_middleware(
 app.include_router(schedule_router)
 app.include_router(ocr_router)
 app.include_router(tag_router)
+app.include_router(badword_router)
 
 
 @app.get("/", response_class=HTMLResponse)


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #34

---
## 🎨 작업 내용 (What)
- CLOVA Studio LLM 활용한 금칙어 필터링 API 구현
- POST /badword/check 엔드포인트 추가
- LLM 분석 실패 시 isBlocked: false 반환하는 예외 처리 구현
- main.py에 badword 라우터 등록

---
## 🧭 작업 목적 (Why)
단순 리스트 방식의 금칙어 필터링 한계를 극복하고 AI가 문맥을 파악하여 욕설/혐오 표현을 정확하게 탐지

---
## 🧩 변경 범위
- [x] API 엔드포인트
- [x] 서버 로직
- [x] 요청 / 응답 구조
- [x] 예외 처리
- [x] 설정 / 환경

---
## 🧪 테스트 방법
- [x] 로컬 실행 확인
- [x] API 호출 테스트 (Swagger /badword/check)
- [x] 에러 로그 확인

---
## ⚠️ 참고 사항

**수정된 파일**
- `features/badword/__init__.py` - 새로 생성
- `features/badword/models.py` - 새로 생성
- `features/badword/router.py` - 새로 생성
- `features/badword/service.py` - 새로 생성
- `main.py` - badword 라우터 등록

**환경 설정 (팀원 필수 확인!)**
- `Ai/app/.env`에 아래 항목 추가 필요 (값은 별도 공유 예정)
  - BADWORD_API_KEY
  - BADWORD_API_URL

---
## ✅ 체크리스트
- [x] main 브랜치에 직접 push 하지 않음
- [x] 해당 브랜치에서 작업함
- [x] 불필요한 print / debug 코드 제거
- [x] PR 단위가 과도하게 크지 않음